### PR TITLE
Fix explicit duration unit handling and add tests

### DIFF
--- a/lib/jetstream_bridge/core/duration.rb
+++ b/lib/jetstream_bridge/core/duration.rb
@@ -70,7 +70,7 @@ module JetstreamBridge
         # Preserve existing heuristic for compatibility
         num >= 1_000 ? num : num * 1_000
       else
-        coerce_numeric_to_ms(i.to_f, default_unit)
+        coerce_numeric_to_ms(num.to_f, default_unit)
       end
     end
 

--- a/spec/core/duration_spec.rb
+++ b/spec/core/duration_spec.rb
@@ -1,0 +1,25 @@
+require 'jetstream_bridge/core/duration'
+
+RSpec.describe JetstreamBridge::Duration do
+  describe '.to_millis' do
+    context 'with explicit unit' do
+      it 'converts seconds to milliseconds' do
+        expect(described_class.to_millis(2, default_unit: :s)).to eq(2_000)
+      end
+
+      it 'converts milliseconds to milliseconds without change' do
+        expect(described_class.to_millis(2, default_unit: :ms)).to eq(2)
+      end
+    end
+
+    context 'with auto unit' do
+      it 'uses seconds for small integers' do
+        expect(described_class.to_millis(2)).to eq(2_000)
+      end
+
+      it 'uses milliseconds for large integers' do
+        expect(described_class.to_millis(1_500)).to eq(1_500)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fix incorrect variable reference in `Duration#int_to_ms`
- add specs covering integer to milliseconds conversion

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403)*
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92700ac88325ba9e41a817579b08