### PR TITLE
Add publisher and consumer message processing specs

### DIFF
--- a/spec/consumer/message_processor_spec.rb
+++ b/spec/consumer/message_processor_spec.rb
@@ -1,0 +1,63 @@
+require 'jetstream_bridge'
+
+RSpec.describe JetstreamBridge::MessageProcessor do
+  let(:jts) { double('jetstream') }
+  let(:handler) { double('handler') }
+  let(:dlq) { instance_double(JetstreamBridge::DlqPublisher) }
+  let(:processor) { described_class.new(jts, handler, dlq: dlq) }
+
+  let(:metadata) do
+    double('metadata', num_delivered: deliveries, sequence: 1, consumer: 'dur', stream: 'stream')
+  end
+
+  let(:msg) do
+    double('msg',
+           data: { foo: 'bar' }.to_json,
+           header: { 'nats-msg-id' => 'abc-123' },
+           subject: 'test.subject',
+           metadata: metadata,
+           ack: nil,
+           nak: nil)
+  end
+
+  after { JetstreamBridge.reset! }
+
+  context 'when handler succeeds' do
+    let(:deliveries) { 1 }
+
+    it 'acks the message' do
+      expect(handler).to receive(:call).with(JSON.parse(msg.data), msg.subject, deliveries)
+      expect(msg).to receive(:ack)
+      expect(dlq).not_to receive(:publish)
+      processor.handle_message(msg)
+    end
+  end
+
+  context 'when handler raises a standard error' do
+    let(:deliveries) { 2 }
+
+    it 'naks the message' do
+      allow(handler).to receive(:call).and_raise(StandardError, 'boom')
+      expect(msg).to receive(:nak)
+      expect(dlq).not_to receive(:publish)
+      processor.handle_message(msg)
+    end
+  end
+
+  context 'when handler raises an unrecoverable error' do
+    let(:deliveries) { 3 }
+
+    it 'acks and publishes to the DLQ' do
+      allow(handler).to receive(:call).and_raise(ArgumentError, 'bad')
+      expect(msg).to receive(:ack)
+      expect(dlq).to receive(:publish) do |m, ctx, reason:, error_class:, error_message:|
+        expect(m).to eq(msg)
+        expect(ctx.event_id).to eq('abc-123')
+        expect(reason).to eq('unrecoverable')
+        expect(error_class).to eq('ArgumentError')
+        expect(error_message).to eq('bad')
+      end
+      processor.handle_message(msg)
+    end
+  end
+end

--- a/spec/publisher/publisher_spec.rb
+++ b/spec/publisher/publisher_spec.rb
@@ -1,0 +1,35 @@
+require 'jetstream_bridge'
+
+RSpec.describe JetstreamBridge::Publisher do
+  let(:jts) { double('jetstream') }
+  let(:ack) { double('ack', duplicate?: false, error: nil) }
+  subject(:publisher) { described_class.new }
+
+  before do
+    JetstreamBridge.reset!
+    JetstreamBridge.configure do |c|
+      c.destination_app = 'dest'
+      c.app_name        = 'source'
+      c.env             = 'test'
+    end
+    allow(JetstreamBridge::Connection).to receive(:connect!).and_return(jts)
+    allow(jts).to receive(:publish).and_return(ack)
+  end
+
+  after { JetstreamBridge.reset! }
+
+  let(:payload) { { 'id' => '1', 'name' => 'Ada' } }
+
+  it 'publishes with nats-msg-id header matching envelope event_id' do
+    expect(jts).to receive(:publish) do |subject, data, header:|
+      envelope = JSON.parse(data)
+      expect(subject).to eq('test.source.sync.dest')
+      expect(header['nats-msg-id']).to eq(envelope['event_id'])
+      ack
+    end
+
+    expect(
+      publisher.publish(resource_type: 'user', event_type: 'created', payload: payload)
+    ).to be(true)
+  end
+end


### PR DESCRIPTION
## Summary
- test publisher sets `nats-msg-id` header matching event id
- test message processor acknowledges, nacks, or DLQs messages

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: command not found due to missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97c0751c8325b5ae8c99d45ab55f