### PR TITLE
Optimize JSON utilities and enhance duration helpers

### DIFF
--- a/lib/jetstream_bridge/core/duration.rb
+++ b/lib/jetstream_bridge/core/duration.rb
@@ -60,7 +60,10 @@ module JetstreamBridge
 
     # Normalize an array of durations into integer milliseconds.
     def normalize_list_to_millis(values, default_unit: :auto)
-      Array(values).map { |v| to_millis(v, default_unit: default_unit) }
+      vals = Array(values)
+      return [] if vals.empty?
+
+      vals.map { |v| to_millis(v, default_unit: default_unit) }
     end
 
     # --- internal helpers ---

--- a/lib/jetstream_bridge/core/model_utils.rb
+++ b/lib/jetstream_bridge/core/model_utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oj'
+
 module JetstreamBridge
   module ModelUtils
     module_function
@@ -36,15 +38,18 @@ module JetstreamBridge
     end
 
     def json_dump(obj)
-      obj.is_a?(String) ? obj : JSON.generate(obj)
-    rescue
+      return obj if obj.is_a?(String)
+
+      Oj.dump(obj, mode: :compat)
+    rescue Oj::Error, TypeError
       obj.to_s
     end
 
     def json_load(str)
       return str if str.is_a?(Hash)
-      JSON.parse(str.to_s)
-    rescue
+
+      Oj.load(str.to_s, mode: :strict)
+    rescue Oj::Error
       {}
     end
   end

--- a/spec/core/duration_spec.rb
+++ b/spec/core/duration_spec.rb
@@ -32,4 +32,15 @@ RSpec.describe JetstreamBridge::Duration do
       end
     end
   end
+
+  describe '.normalize_list_to_millis' do
+    it 'converts mixed durations into milliseconds' do
+      list = ['1s', '500ms', 2]
+      expect(described_class.normalize_list_to_millis(list)).to eq([1_000, 500, 2_000])
+    end
+
+    it 'returns an empty array for nil input' do
+      expect(described_class.normalize_list_to_millis(nil)).to eq([])
+    end
+  end
 end

--- a/spec/core/model_utils_spec.rb
+++ b/spec/core/model_utils_spec.rb
@@ -1,0 +1,29 @@
+require 'jetstream_bridge/core/model_utils'
+
+RSpec.describe JetstreamBridge::ModelUtils do
+  describe '.json_dump' do
+    it 'returns the string unchanged' do
+      json = '{"a":1}'
+      expect(described_class.json_dump(json)).to eq(json)
+    end
+
+    it 'serializes objects to JSON' do
+      expect(described_class.json_dump({ a: 1 })).to eq('{"a":1}')
+    end
+  end
+
+  describe '.json_load' do
+    it 'parses JSON strings into hashes' do
+      expect(described_class.json_load('{"a":1}')).to eq('a' => 1)
+    end
+
+    it 'returns hash input untouched' do
+      h = { 'a' => 1 }
+      expect(described_class.json_load(h)).to equal(h)
+    end
+
+    it 'returns empty hash for invalid JSON' do
+      expect(described_class.json_load('invalid')).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- use Oj for faster JSON dump/load with safe error handling
- short-circuit empty input in duration normalization for efficiency
- expand test coverage for JSON helpers and duration list normalization

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68ac998217b88325a68c8aec8c2607d2