### PR TITLE
Use Oj for JSON handling

### DIFF
--- a/lib/jetstream_bridge/consumer/consumer.rb
+++ b/lib/jetstream_bridge/consumer/consumer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 require 'securerandom'
 require_relative '../core/connection'
 require_relative '../core/duration'

--- a/lib/jetstream_bridge/consumer/dlq_publisher.rb
+++ b/lib/jetstream_bridge/consumer/dlq_publisher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 require 'time'
 require_relative '../core/logging'
 
@@ -46,7 +46,7 @@ module JetstreamBridge
       headers['x-dead-letter'] = 'true'
       headers['x-dlq-reason']  = reason
       headers['x-deliveries']  = deliveries.to_s
-      headers['x-dlq-context'] = JSON.generate(envelope)
+      headers['x-dlq-context'] = Oj.dump(envelope, mode: :compat)
       headers
     end
   end

--- a/lib/jetstream_bridge/consumer/inbox/inbox_message.rb
+++ b/lib/jetstream_bridge/consumer/inbox/inbox_message.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 
 module JetstreamBridge
   # Immutable value object for a single NATS message.
@@ -19,8 +19,8 @@ module JetstreamBridge
 
       raw  = m.data
       body = begin
-        JSON.parse(raw)
-      rescue StandardError
+        Oj.load(raw, mode: :strict)
+      rescue Oj::Error
         {}
       end
 

--- a/lib/jetstream_bridge/consumer/message_processor.rb
+++ b/lib/jetstream_bridge/consumer/message_processor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 require_relative '../core/logging'
 require_relative 'message_context'
 require_relative 'dlq_publisher'
@@ -37,12 +37,8 @@ module JetstreamBridge
 
     def parse_message(msg, ctx)
       data = msg.data
-      if defined?(Oj)
-        Oj.load(data, mode: :strict)
-      else
-        JSON.parse(data)
-      end
-    rescue JSON::ParserError => e
+      Oj.load(data, mode: :strict)
+    rescue Oj::ParseError => e
       @dlq.publish(msg, ctx,
                    reason: 'malformed_json', error_class: e.class.name, error_message: e.message)
       msg.ack

--- a/lib/jetstream_bridge/core/connection.rb
+++ b/lib/jetstream_bridge/core/connection.rb
@@ -2,7 +2,7 @@
 
 require 'nats/io/client'
 require 'singleton'
-require 'json'
+require 'oj'
 require_relative 'duration'
 require_relative 'logging'
 require_relative 'config'

--- a/lib/jetstream_bridge/core/model_codec_setup.rb
+++ b/lib/jetstream_bridge/core/model_codec_setup.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oj'
+
 module JetstreamBridge
   module ModelCodecSetup
     module_function
@@ -17,7 +19,7 @@ module JetstreamBridge
         next unless column?(klass, attr)
         next if json_column?(klass, attr) || already_serialized?(klass, attr)
 
-        klass.serialize attr.to_sym, coder: JSON
+        klass.serialize attr.to_sym, coder: Oj
       end
     rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError
       # ignore when schema isn’t available yet

--- a/lib/jetstream_bridge/inbox_event.rb
+++ b/lib/jetstream_bridge/inbox_event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oj'
+
 begin
   require 'active_record'
 rescue LoadError
@@ -84,8 +86,8 @@ module JetstreamBridge
         v = self[:payload]
         case v
         when String then begin
-          JSON.parse(v)
-        rescue StandardError
+          Oj.load(v, mode: :strict)
+        rescue Oj::Error
           {}
         end
         when Hash then v

--- a/lib/jetstream_bridge/outbox_event.rb
+++ b/lib/jetstream_bridge/outbox_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 
 begin
   require 'active_record'
@@ -93,8 +93,8 @@ module JetstreamBridge
         v = self[:payload]
         case v
         when String then begin
-          JSON.parse(v)
-        rescue StandardError
+          Oj.load(v, mode: :strict)
+        rescue Oj::Error
           {}
         end
         when Hash then v

--- a/lib/jetstream_bridge/publisher/publisher.rb
+++ b/lib/jetstream_bridge/publisher/publisher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 require 'securerandom'
 require_relative '../core/connection'
 require_relative '../core/logging'
@@ -50,7 +50,7 @@ module JetstreamBridge
     def do_publish?(subject, envelope)
       headers = { 'nats-msg-id' => envelope['event_id'] }
 
-      ack = @jts.publish(subject, JSON.generate(envelope), header: headers)
+      ack = @jts.publish(subject, Oj.dump(envelope, mode: :compat), header: headers)
       duplicate = ack.respond_to?(:duplicate?) && ack.duplicate?
       msg = "Published #{subject} event_id=#{envelope['event_id']}"
       msg += ' (duplicate)' if duplicate

--- a/lib/jetstream_bridge/topology/overlap_guard.rb
+++ b/lib/jetstream_bridge/topology/overlap_guard.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require 'oj'
 require_relative 'subject_matcher'
 require_relative '../core/logging'
 
@@ -68,8 +68,8 @@ module JetstreamBridge
 
       def js_api_request(jts, subject, payload = {})
         # JetStream client should expose the underlying NATS client as `nc`
-        msg = jts.nc.request(subject, JSON.dump(payload))
-        JSON.parse(msg.data)
+        msg = jts.nc.request(subject, Oj.dump(payload, mode: :compat))
+        Oj.load(msg.data, mode: :strict)
       end
 
       def conflict_message(target, conflicts)

--- a/spec/consumer/message_processor_spec.rb
+++ b/spec/consumer/message_processor_spec.rb
@@ -1,4 +1,5 @@
 require 'jetstream_bridge'
+require 'oj'
 
 RSpec.describe JetstreamBridge::MessageProcessor do
   let(:jts) { double('jetstream') }
@@ -12,7 +13,7 @@ RSpec.describe JetstreamBridge::MessageProcessor do
 
   let(:msg) do
     double('msg',
-           data: { foo: 'bar' }.to_json,
+           data: Oj.dump({ foo: 'bar' }),
            header: { 'nats-msg-id' => 'abc-123' },
            subject: 'test.subject',
            metadata: metadata,
@@ -26,7 +27,7 @@ RSpec.describe JetstreamBridge::MessageProcessor do
     let(:deliveries) { 1 }
 
     it 'acks the message' do
-      expect(handler).to receive(:call).with(JSON.parse(msg.data), msg.subject, deliveries)
+      expect(handler).to receive(:call).with(Oj.load(msg.data, mode: :strict), msg.subject, deliveries)
       expect(msg).to receive(:ack)
       expect(dlq).not_to receive(:publish)
       processor.handle_message(msg)

--- a/spec/publisher/publisher_spec.rb
+++ b/spec/publisher/publisher_spec.rb
@@ -1,4 +1,5 @@
 require 'jetstream_bridge'
+require 'oj'
 
 RSpec.describe JetstreamBridge::Publisher do
   let(:jts) { double('jetstream') }
@@ -22,7 +23,7 @@ RSpec.describe JetstreamBridge::Publisher do
 
   it 'publishes with nats-msg-id header matching envelope event_id' do
     expect(jts).to receive(:publish) do |subject, data, header:|
-      envelope = JSON.parse(data)
+      envelope = Oj.load(data, mode: :strict)
       expect(subject).to eq('test.source.sync.dest')
       expect(header['nats-msg-id']).to eq(envelope['event_id'])
       ack


### PR DESCRIPTION
## Summary
- replace JSON parsing and generation with Oj across the library and specs
- configure ActiveRecord serialization to use Oj

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b87a868832582f55b6025cf8458