### PR TITLE
Handle ack/nak for InboxMessage

### DIFF
--- a/lib/jetstream_bridge/consumer/inbox/inbox_message.rb
+++ b/lib/jetstream_bridge/consumer/inbox/inbox_message.rb
@@ -12,6 +12,7 @@ module JetstreamBridge
       seq        = meta.respond_to?(:stream_sequence) ? meta.stream_sequence : nil
       deliveries = meta.respond_to?(:num_delivered)   ? meta.num_delivered   : nil
       stream     = meta.respond_to?(:stream)          ? meta.stream          : nil
+      consumer   = meta.respond_to?(:consumer)        ? meta.consumer        : nil
       subject    = msg.subject.to_s
 
       headers = {}
@@ -27,10 +28,10 @@ module JetstreamBridge
       id = (headers['nats-msg-id'] || body['event_id']).to_s.strip
       id = "seq:#{seq}" if id.empty?
 
-      new(msg, seq, deliveries, stream, subject, headers, body, raw, id, Time.now.utc)
+      new(msg, seq, deliveries, stream, subject, headers, body, raw, id, Time.now.utc, consumer)
     end
 
-    def initialize(msg, seq, deliveries, stream, subject, headers, body, raw, event_id, now)
+    def initialize(msg, seq, deliveries, stream, subject, headers, body, raw, event_id, now, consumer = nil)
       @msg        = msg
       @seq        = seq
       @deliveries = deliveries
@@ -41,10 +42,32 @@ module JetstreamBridge
       @raw        = raw
       @event_id   = event_id
       @now        = now
+      @consumer   = consumer
     end
 
     def body_for_store
       body.empty? ? raw : body
+    end
+
+    def data
+      raw
+    end
+
+    def header
+      headers
+    end
+
+    def metadata
+      @metadata ||= Struct.new(:num_delivered, :sequence, :consumer, :stream)
+                           .new(deliveries, seq, @consumer, stream)
+    end
+
+    def ack(*args, **kwargs)
+      msg.ack(*args, **kwargs) if msg.respond_to?(:ack)
+    end
+
+    def nak(*args, **kwargs)
+      msg.nak(*args, **kwargs) if msg.respond_to?(:nak)
     end
   end
 end

--- a/spec/consumer/inbox_message_spec.rb
+++ b/spec/consumer/inbox_message_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'jetstream_bridge'
+require 'oj'
+
+RSpec.describe JetstreamBridge::InboxMessage do
+  let(:metadata) do
+    double('metadata',
+           stream_sequence: 1,
+           num_delivered: 2,
+           stream: 'test',
+           consumer: 'durable')
+  end
+
+  let(:nats_msg) do
+    double('nats-msg',
+           subject: 'inbox.subject',
+           data: Oj.dump({ foo: 'bar' }),
+           header: { 'nats-msg-id' => 'id-123' },
+           metadata: metadata,
+           ack: nil,
+           nak: nil)
+  end
+
+  subject(:msg) { described_class.from_nats(nats_msg) }
+
+  it 'delegates ack to the underlying message' do
+    expect(nats_msg).to receive(:ack)
+    msg.ack
+  end
+
+  it 'delegates nak to the underlying message' do
+    expect(nats_msg).to receive(:nak).with(:foo)
+    msg.nak(:foo)
+  end
+end


### PR DESCRIPTION
## Summary
- delegate ack/nak/data/header/metadata to underlying NATS message so InboxMessage mimics message API
- add specs verifying ack/nak delegation

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68acae889300832580c54e0b5960498e