### PR TITLE
Allow Consumer.new without durable name or batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,19 @@ If **Outbox** is enabled, the publish call:
 ## 📥 Consume Events
 
 ```ruby
-JetstreamBridge::Consumer.new(
-  durable_name: "#{Rails.env}-#{app_name}-workers",
-  batch_size:   25
-) do |event, subject, deliveries|
+JetstreamBridge::Consumer.new do |event, subject, deliveries|
   # Your idempotent domain logic here
   # `event` is the parsed envelope hash
   UserCreatedHandler.call(event["payload"])
+end.run!
+```
+
+`durable_name` and `batch_size` default to the configured values and can be
+overridden if needed:
+
+```ruby
+JetstreamBridge::Consumer.new(durable_name: 'my-durable', batch_size: 10) do |event, subject, deliveries|
+  # ...
 end.run!
 ```
 

--- a/lib/jetstream_bridge/consumer/consumer.rb
+++ b/lib/jetstream_bridge/consumer/consumer.rb
@@ -20,13 +20,12 @@ module JetstreamBridge
     IDLE_SLEEP_SECS       = 0.05
     MAX_IDLE_BACKOFF_SECS = 1.0
 
-    def initialize(durable_name: JetstreamBridge.config.durable_name,
-                   batch_size: DEFAULT_BATCH_SIZE, &block)
+    def initialize(durable_name: nil, batch_size: nil, &block)
       raise ArgumentError, 'handler block required' unless block_given?
 
       @handler       = block
-      @batch_size    = Integer(batch_size)
-      @durable       = durable_name
+      @batch_size    = Integer(batch_size || DEFAULT_BATCH_SIZE)
+      @durable       = durable_name || JetstreamBridge.config.durable_name
       @idle_backoff  = IDLE_SLEEP_SECS
       @running       = true
       @jts           = Connection.connect!

--- a/spec/consumer/consumer_spec.rb
+++ b/spec/consumer/consumer_spec.rb
@@ -23,14 +23,17 @@ RSpec.describe JetstreamBridge::Consumer do
 
   describe 'initialization' do
     it 'ensures and subscribes the consumer' do
-      described_class.new(durable_name: 'durable') { |*| nil }
+      described_class.new { |*| nil }
+      expect(JetstreamBridge::SubscriptionManager)
+        .to have_received(:new)
+        .with(jts, JetstreamBridge.config.durable_name, JetstreamBridge.config)
       expect(sub_mgr).to have_received(:ensure_consumer!)
       expect(sub_mgr).to have_received(:subscribe!)
     end
   end
 
   describe '#process_batch' do
-    subject(:consumer) { described_class.new(durable_name: 'durable') { |*| nil } }
+    subject(:consumer) { described_class.new { |*| nil } }
 
     it 'processes fetched messages' do
       msg1 = double('msg1')


### PR DESCRIPTION
## Summary
- simplify Consumer defaults so `durable_name` and `batch_size` are optional
- document implicit defaults and show streamlined usage in README
- adjust specs to cover initialization without explicit options

## Testing
- `bundle exec rubocop`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68acfbff6fdc832585fac021edc9f503