### PR TITLE
Add tests for topology helpers

### DIFF
--- a/spec/topology/stream_support_spec.rb
+++ b/spec/topology/stream_support_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'jetstream_bridge/topology/stream'
+
+RSpec.describe JetstreamBridge::StreamSupport do
+  describe '.normalize_subjects' do
+    it 'flattens, stringifies and removes blanks' do
+      list = ['a', ['b', nil, ''], :c, 'a']
+      expect(described_class.normalize_subjects(list)).to eq(%w[a b c])
+    end
+
+    it 'returns empty array for nil input' do
+      expect(described_class.normalize_subjects(nil)).to eq([])
+    end
+  end
+
+  describe '.missing_subjects' do
+    it 'returns subjects not covered by existing patterns' do
+      existing = ['a.*', 'b.>']
+      desired  = ['a.b', 'b.c.d', 'c']
+      expect(described_class.missing_subjects(existing, desired)).to eq(['c'])
+    end
+  end
+
+  describe '.stream_not_found?' do
+    it 'detects stream not found errors by message' do
+      err1 = double('err', message: 'Stream Not Found')
+      err2 = double('err', message: '404')
+      err3 = double('err', message: 'other')
+      expect(described_class.stream_not_found?(err1)).to be_truthy
+      expect(described_class.stream_not_found?(err2)).to be_truthy
+      expect(described_class.stream_not_found?(err3)).to be_falsey
+    end
+  end
+
+  describe '.overlap_error?' do
+    it 'detects overlap errors by message' do
+      err1 = double('err', message: 'Subjects overlap')
+      err2 = double('err', message: 'err_code=10065')
+      err3 = double('err', message: '400')
+      err4 = double('err', message: 'other')
+      expect(described_class.overlap_error?(err1)).to be_truthy
+      expect(described_class.overlap_error?(err2)).to be_truthy
+      expect(described_class.overlap_error?(err3)).to be_truthy
+      expect(described_class.overlap_error?(err4)).to be_falsey
+    end
+  end
+end

--- a/spec/topology/subject_matcher_spec.rb
+++ b/spec/topology/subject_matcher_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'jetstream_bridge/topology/subject_matcher'
+
+RSpec.describe JetstreamBridge::SubjectMatcher do
+  describe '.match?' do
+    it 'matches exact subjects' do
+      expect(described_class.match?('a.b', 'a.b')).to be true
+      expect(described_class.match?('a.b', 'a.c')).to be false
+    end
+
+    it 'supports single-token wildcards' do
+      expect(described_class.match?('a.*.c', 'a.b.c')).to be true
+      expect(described_class.match?('a.*.c', 'a.b.d')).to be false
+    end
+
+    it 'requires * to consume exactly one token' do
+      expect(described_class.match?('a.*', 'a')).to be false
+      expect(described_class.match?('*', 'a.b')).to be false
+    end
+
+    it 'supports tail wildcards' do
+      expect(described_class.match?('a.>', 'a.b.c')).to be true
+      expect(described_class.match?('>', 'a.b.c')).to be true
+      expect(described_class.match?('a.>', 'b.c')).to be false
+    end
+  end
+
+  describe '.covered?' do
+    it 'returns true when any pattern matches the subject' do
+      patterns = ['a.*', 'b.>']
+      expect(described_class.covered?(patterns, 'a.b')).to be true
+      expect(described_class.covered?(patterns, 'b.c.d')).to be true
+      expect(described_class.covered?(patterns, 'c')).to be false
+    end
+  end
+
+  describe '.overlap?' do
+    it 'detects overlapping wildcard patterns' do
+      expect(described_class.overlap?('a.*.c', 'a.b.*')).to be true
+      expect(described_class.overlap?('a.*.c', 'a.*.d')).to be false
+      expect(described_class.overlap?('a.>', 'a')).to be true
+      expect(described_class.overlap?('a.*', 'a')).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add RSpec tests for SubjectMatcher covering wildcard and overlap semantics
- test StreamSupport utilities for normalization, coverage and error detection

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68ad0122359483258c8fde8e333cab28