### PR TITLE
Add debug logging helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'Rakefile'
     - 'tasks/**/*.rake'
+    - 'jetstream_bridge.gemspec'
 
 Metrics/MethodLength:
   Max: 25

--- a/lib/jetstream_bridge/core/logging.rb
+++ b/lib/jetstream_bridge/core/logging.rb
@@ -24,6 +24,10 @@ module JetstreamBridge
       logger.public_send(level, message)
     end
 
+    def debug(msg, tag: nil)
+      log(:debug, msg, tag: tag)
+    end
+
     def info(msg, tag: nil)
       log(:info, msg, tag: tag)
     end

--- a/spec/core/logging_spec.rb
+++ b/spec/core/logging_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe JetstreamBridge::Logging do
     io.rewind
     expect(io.string).to include('[Spec] hello')
   end
+
+  it 'logs debug messages' do
+    io = StringIO.new
+    custom_logger = Logger.new(io)
+    JetstreamBridge.configure(logger: custom_logger)
+
+    described_class.debug('dbg', tag: 'Spec')
+
+    io.rewind
+    expect(io.string).to include('[Spec] dbg')
+  end
 end


### PR DESCRIPTION
## Summary
- add `debug` logging helper
- test debug logging
- exclude gemspec from RuboCop BlockLength

## Testing
- `bundle exec rubocop`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68ad77e78a8c8325b35cc9cbb9a41a83